### PR TITLE
Fix duplicate comics in feed by deduplicating cached items

### DIFF
--- a/internal/oglaf/provider.go
+++ b/internal/oglaf/provider.go
@@ -255,6 +255,8 @@ func (p *Provider) processComicsIncremental(contentDB *database.Database) ([]pro
 	}
 
 	// 2. Extract images only for unprocessed comics
+	// Track which links were just processed to avoid duplicates with cached items
+	justProcessed := make(map[string]bool)
 	var transformedItems []providers.FeedItem
 	for _, item := range unprocessed {
 		imageURL, extractErr := extractFullComicURL(item.Link)
@@ -279,18 +281,20 @@ func (p *Provider) processComicsIncremental(contentDB *database.Database) ([]pro
 		transformed.Description = comicDescription(item.Link, imageURL, item.Title)
 
 		transformedItems = append(transformedItems, transformed)
+		justProcessed[item.Link] = true
 	}
 
-	// 3. Include already processed cached items
+	// 3. Include already processed cached items, skipping any just processed above
 	cachedItems, err := getProcessedComics(contentDB, 50)
 	if err != nil {
 		slog.Warn("Failed to get processed comics", "error", err)
 	} else {
 		for _, item := range cachedItems {
-			// Ensure description is set for cached items
-			if item.Description == "" {
-				item.Description = comicDescription(item.Link(), item.imageURL, item.Title())
+			if justProcessed[item.Link()] {
+				continue
 			}
+			// Always set description for cached items to ensure consistent content
+			item.Description = comicDescription(item.Link(), item.imageURL, item.Title())
 			transformedItems = append(transformedItems, item)
 		}
 	}


### PR DESCRIPTION
## Summary
Fixed an issue where comics could appear twice in the feed when they were both in the newly processed batch and the cached items list. The fix ensures that cached items are skipped if they were just processed in the current run.

## Key Changes
- Added `justProcessed` map to track links that were processed in the current batch
- Modified cached items loop to skip any items that were just processed, preventing duplicates
- Changed description handling for cached items from conditional to always setting it, ensuring consistent content across all items

## Implementation Details
- The `justProcessed` map is populated as unprocessed comics are transformed and added to the results
- When iterating through cached items, we check this map before including them in the final feed
- This approach maintains the order of newly processed items first, followed by cached items, while preventing duplicates

https://claude.ai/code/session_01G4QDeR8Kg4SB1HiTLhkYJK