### PR TITLE
fix(opengraph): clean fetched data inside singleflight

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,11 @@ tasks:
     cmds:
       - go test ./...
 
+  test-race:
+    desc: "Run tests with the race detector"
+    cmds:
+      - go test -race -tags=ci ./...
+
   lint:
     desc: "Run linter and formatter"
     cmds:

--- a/pkg/opengraph/fetcher.go
+++ b/pkg/opengraph/fetcher.go
@@ -99,7 +99,8 @@ func (f *Fetcher) FetchDataWithContext(ctx context.Context, targetURL string) (*
 			data = newFailurePlaceholder(targetURL)
 		}
 	} else if data != nil {
-		cleanupData(data, targetURL)
+		// cleanupData already ran inside the singleflight function in
+		// doFetchConditional; the returned pointer is shared between waiters.
 		slog.Debug("Successfully fetched OpenGraph data", "url", targetURL, "title", data.Title)
 	}
 

--- a/pkg/opengraph/fetcher_test.go
+++ b/pkg/opengraph/fetcher_test.go
@@ -137,7 +137,9 @@ func TestFetchFreshDataAndFetchDataSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fetchFreshData() error = %v", err)
 	}
-	if fresh == nil || fresh.Title != "Fallback title" || fresh.Description != "OG Description" || fresh.Image != "/img.png" {
+	// fetchFreshData cleans the data inside the singleflight function, so the
+	// image URL is already resolved against the page URL here.
+	if fresh == nil || fresh.Title != "Fallback title" || fresh.Description != "OG Description" || fresh.Image != "http://example.invalid/img.png" {
 		t.Fatalf("fetchFreshData() = %#v", fresh)
 	}
 

--- a/pkg/opengraph/request.go
+++ b/pkg/opengraph/request.go
@@ -105,6 +105,9 @@ func (f *Fetcher) doFetchConditional(ctx context.Context, targetURL, etag, lastM
 		ExpiresAt:    now.Add(time.Duration(DefaultCacheHours) * time.Hour),
 	}
 	extractOpenGraphTags(doc, data)
+	// Clean up inside the singleflight function: every waiter receives this same
+	// *Data pointer, so mutation must happen once, before the result is shared.
+	cleanupData(data, targetURL)
 	slog.Debug("Extracted OpenGraph data", "url", targetURL, "title", data.Title, "hasDescription", data.Description != "")
 	return data, nil
 }


### PR DESCRIPTION
Fixes #67.

## Problem

`FetchDataWithContext` coalesces concurrent fetches for the same URL through singleflight, so every waiter receives the same `*Data` pointer. Each caller then mutated that shared struct in place via `cleanupData`, giving an unsynchronized read/write on `Title`, `Description`, `Image`, and `SiteName`. `cleanupData` is not idempotent (500-char truncation), so interleaved runs could produce doubly-truncated values, and a torn read could reach `opengraph.db` through `SaveCachedData`.

Reproduced before the fix:

```
go test -race -tags=ci ./pkg/opengraph/ -run TestFetchData_SingleflightCoalescesConcurrentFetches
WARNING: DATA RACE  ->  --- FAIL: race detected during execution of test
```

## Change

Option 1 from the issue: `cleanupData` now runs inside the singleflight function in `doFetchConditional`, right after `extractOpenGraphTags`. The mutation happens once before the result is shared, and the singleflight guarantee orders it before every waiter's read. This also drops the duplicated cleanup each waiter used to redo.

`fetchFreshData` now returns already-cleaned data, so `TestFetchFreshDataAndFetchDataSuccess` expects the resolved absolute image URL instead of the raw `/img.png`.

Added a `test-race` task (`go test -race -tags=ci ./...`). CI still runs `test-ci` without `-race`; wiring a race job in is a separate call.

## Verification

- `task test-race` — clean, no data race across all packages.
- `task build` (runs `test` and `lint`) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)