### PR TITLE
fix(database): apply SQLite pragmas per connection via DSN

### DIFF
--- a/internal/bulletin/store.go
+++ b/internal/bulletin/store.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	_ "modernc.org/sqlite"
+	"github.com/lepinkainen/feed-forge/pkg/database"
 )
 
 // schema is applied idempotently on Store open. Timestamps use TIMESTAMP
@@ -55,12 +55,8 @@ type Store struct {
 // NewStore opens (creating if needed) the bulletin database at dbPath and
 // applies the schema.
 func NewStore(dbPath string) (*Store, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := database.OpenSQLite(database.SQLiteOptions{Path: dbPath})
 	if err != nil {
-		return nil, fmt.Errorf("open bulletin db: %w", err)
-	}
-	if err := configureSQLite(db); err != nil {
-		_ = db.Close()
 		return nil, err
 	}
 	if _, err := db.ExecContext(context.Background(), schema); err != nil {
@@ -68,23 +64,6 @@ func NewStore(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("apply bulletin schema: %w", err)
 	}
 	return &Store{db: db}, nil
-}
-
-// configureSQLite applies pragmas so that overlapping bulletin-fetch and
-// bulletin-publish processes sharing the database file wait for each other
-// instead of failing immediately with "database is locked".
-func configureSQLite(db *sql.DB) error {
-	ctx := context.Background()
-	for _, pragma := range []string{
-		"PRAGMA busy_timeout=5000",
-		"PRAGMA journal_mode=WAL",
-		"PRAGMA synchronous=NORMAL",
-	} {
-		if _, err := db.ExecContext(ctx, pragma); err != nil {
-			return fmt.Errorf("configure bulletin db %q: %w", pragma, err)
-		}
-	}
-	return nil
 }
 
 // Close closes the underlying database.

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
-
-	_ "modernc.org/sqlite"
 )
 
 func resetDBCache(t *testing.T) {

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -1,0 +1,146 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/lepinkainen/feed-forge/pkg/filesystem"
+
+	_ "modernc.org/sqlite" // SQLite driver, registered as "sqlite"
+)
+
+// Default connection pool limits applied when SQLiteOptions leaves them unset.
+const (
+	DefaultMaxOpenConns = 10
+	DefaultMaxIdleConns = 5
+)
+
+// DefaultBusyTimeout is how long a connection waits for a lock held by another
+// connection or process before it gives up with SQLITE_BUSY.
+const DefaultBusyTimeout = 5 * time.Second
+
+// connectionPragmas are the pragmas that SQLite keeps per connection rather than
+// in the database file. They must travel in the DSN: the driver then applies them
+// to every connection it opens, including the ones database/sql adds to the pool
+// later. Running them as statements after sql.Open would configure one pooled
+// connection and leave the rest at their defaults, which means busy_timeout=0 and
+// an immediate "database is locked (5) (SQLITE_BUSY)" on the first contended
+// write.
+func connectionPragmas(busyTimeout time.Duration) []string {
+	return []string{
+		fmt.Sprintf("busy_timeout=%d", busyTimeout.Milliseconds()),
+		"synchronous=NORMAL",
+		"temp_store=memory",
+		"mmap_size=268435456",
+	}
+}
+
+// SQLiteOptions configures a SQLite connection pool.
+type SQLiteOptions struct {
+	// Path is the database file path. Required.
+	Path string
+	// MaxOpenConns is the maximum number of open connections.
+	// Zero means DefaultMaxOpenConns.
+	MaxOpenConns int
+	// MaxIdleConns is the maximum number of idle connections.
+	// Zero means DefaultMaxIdleConns.
+	MaxIdleConns int
+	// ConnMaxLifetime is the maximum lifetime of a connection.
+	// Zero means connections are reused forever.
+	ConnMaxLifetime time.Duration
+	// BusyTimeout is how long a connection waits for a lock before it returns
+	// SQLITE_BUSY. Zero means DefaultBusyTimeout.
+	BusyTimeout time.Duration
+}
+
+// dsn builds the connection string. The pragmas ride along as query parameters so
+// the driver applies them to every connection. The path is not prefixed with
+// "file:", so the driver treats everything before the "?" as a literal path and no
+// URI escaping is needed.
+func (o SQLiteOptions) dsn() string {
+	busyTimeout := o.BusyTimeout
+	if busyTimeout <= 0 {
+		busyTimeout = DefaultBusyTimeout
+	}
+
+	params := url.Values{"_pragma": connectionPragmas(busyTimeout)}
+	return o.Path + "?" + params.Encode()
+}
+
+// OpenSQLite opens the SQLite database at opts.Path. It creates the parent
+// directory, applies the shared pragmas, sets the connection pool limits, and
+// verifies the connection with Ping. On any failure after the handle is open,
+// the handle is closed before the error is returned.
+func OpenSQLite(opts SQLiteOptions) (*sql.DB, error) {
+	if err := filesystem.EnsureDirectoryExists(opts.Path); err != nil {
+		return nil, fmt.Errorf("create database directory: %w", err)
+	}
+
+	db, err := sql.Open("sqlite", opts.dsn())
+	if err != nil {
+		return nil, fmt.Errorf("open database %s: %w", opts.Path, err)
+	}
+
+	if err := ensureWAL(context.Background(), db); err != nil {
+		closeDBOnError(db)
+		return nil, err
+	}
+
+	applyPoolLimits(db, opts)
+
+	if err := db.Ping(); err != nil {
+		closeDBOnError(db)
+		return nil, fmt.Errorf("ping database %s: %w", opts.Path, err)
+	}
+
+	return db, nil
+}
+
+// applyPoolLimits sets the connection pool limits, substituting the defaults for
+// unset values.
+func applyPoolLimits(db *sql.DB, opts SQLiteOptions) {
+	maxOpen := opts.MaxOpenConns
+	if maxOpen <= 0 {
+		maxOpen = DefaultMaxOpenConns
+	}
+	maxIdle := opts.MaxIdleConns
+	if maxIdle <= 0 {
+		maxIdle = DefaultMaxIdleConns
+	}
+
+	db.SetMaxOpenConns(maxOpen)
+	db.SetMaxIdleConns(maxIdle)
+	db.SetConnMaxLifetime(opts.ConnMaxLifetime)
+}
+
+// ensureWAL switches the database to write-ahead logging. Unlike the pragmas in
+// connectionPragmas, journal_mode is stored in the database file, so one
+// statement on one connection configures the file for every connection and every
+// process that opens it afterwards. WAL lets readers run while a writer holds the
+// write lock, which is what keeps overlapping commands such as bulletin-fetch and
+// bulletin-publish, or the providers that generate runs concurrently, out of each
+// other's way.
+//
+// The mode is only set when the file is not in WAL already: converting a database
+// needs an exclusive lock, so a redundant conversion attempt can fail against a
+// busy file. A database that cannot use WAL at all, such as an in-memory one,
+// reports its own mode and is left alone.
+func ensureWAL(ctx context.Context, db *sql.DB) error {
+	var journalMode string
+	if err := db.QueryRowContext(ctx, "PRAGMA journal_mode;").Scan(&journalMode); err != nil {
+		return fmt.Errorf("read journal mode: %w", err)
+	}
+	if strings.EqualFold(journalMode, "wal") || strings.EqualFold(journalMode, "memory") {
+		return nil
+	}
+
+	if _, err := db.ExecContext(ctx, "PRAGMA journal_mode=WAL"); err != nil {
+		return fmt.Errorf("set journal mode: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/database/sqlite_test.go
+++ b/pkg/database/sqlite_test.go
@@ -1,0 +1,213 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenSQLiteCreatesParentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "deeper", "test.db")
+
+	db, err := OpenSQLite(SQLiteOptions{Path: path})
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("database file not created: %v", err)
+	}
+}
+
+func TestOpenSQLiteAppliesPragmas(t *testing.T) {
+	db, err := OpenSQLite(SQLiteOptions{Path: filepath.Join(t.TempDir(), "test.db")})
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode;").Scan(&journalMode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		t.Errorf("journal_mode = %q, want wal", journalMode)
+	}
+
+	var busyTimeout int
+	if err := db.QueryRow("PRAGMA busy_timeout;").Scan(&busyTimeout); err != nil {
+		t.Fatalf("read busy_timeout: %v", err)
+	}
+	if busyTimeout != 5000 {
+		t.Errorf("busy_timeout = %d, want 5000", busyTimeout)
+	}
+
+	var synchronous int
+	if err := db.QueryRow("PRAGMA synchronous;").Scan(&synchronous); err != nil {
+		t.Fatalf("read synchronous: %v", err)
+	}
+	if synchronous != 1 {
+		t.Errorf("synchronous = %d, want 1 (NORMAL)", synchronous)
+	}
+}
+
+// TestOpenSQLitePragmasApplyToEveryPooledConnection guards the SQLITE_BUSY
+// regression: busy_timeout, synchronous, temp_store and mmap_size live on the
+// connection, not in the database file, so a pool whose pragmas were run as
+// statements after sql.Open configures one connection and leaves every later one
+// at the SQLite defaults.
+func TestOpenSQLitePragmasApplyToEveryPooledConnection(t *testing.T) {
+	db, err := OpenSQLite(SQLiteOptions{Path: filepath.Join(t.TempDir(), "test.db")})
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	pragmas := map[string]int{
+		"busy_timeout": 5000,
+		"synchronous":  1,
+		"temp_store":   2,
+	}
+
+	// Hold each connection open so that the next db.Conn call is forced to create
+	// a fresh one instead of reusing a connection that is already configured.
+	var held []*sql.Conn
+	t.Cleanup(func() {
+		for _, c := range held {
+			_ = c.Close()
+		}
+	})
+
+	for i := range 3 {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("db.Conn() #%d error = %v", i+1, err)
+		}
+		held = append(held, conn)
+
+		for pragma, want := range pragmas {
+			var got int
+			if err := conn.QueryRowContext(ctx, "PRAGMA "+pragma+";").Scan(&got); err != nil {
+				t.Fatalf("read %s on connection #%d: %v", pragma, i+1, err)
+			}
+			if got != want {
+				t.Errorf("connection #%d: %s = %d, want %d", i+1, pragma, got, want)
+			}
+		}
+	}
+}
+
+// TestOpenSQLiteContendedWriteWaits reproduces the failure seen in production:
+// two handles on one database file, one of them writing while the other holds the
+// write lock. With busy_timeout in force on every connection the second writer
+// waits; without it the write fails immediately with SQLITE_BUSY.
+func TestOpenSQLiteContendedWriteWaits(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "contended.db")
+	ctx := context.Background()
+
+	writer, err := OpenSQLite(SQLiteOptions{Path: path, BusyTimeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("OpenSQLite(writer) error = %v", err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+
+	if _, err := writer.ExecContext(ctx, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	blocker, err := OpenSQLite(SQLiteOptions{Path: path, BusyTimeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("OpenSQLite(blocker) error = %v", err)
+	}
+	t.Cleanup(func() { _ = blocker.Close() })
+
+	// Pin the writer's first connection, so the contended write below has to run
+	// on a connection the pool creates afterwards.
+	pinned, err := writer.Conn(ctx)
+	if err != nil {
+		t.Fatalf("writer.Conn() error = %v", err)
+	}
+	t.Cleanup(func() { _ = pinned.Close() })
+
+	// Take the write lock on the blocker and hold it briefly.
+	tx, err := blocker.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, "INSERT INTO t (v) VALUES ('blocker')"); err != nil {
+		t.Fatalf("blocker insert: %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		close(released)
+		if err := tx.Commit(); err != nil {
+			t.Errorf("blocker commit: %v", err)
+		}
+	}()
+
+	if _, err := writer.ExecContext(ctx, "INSERT INTO t (v) VALUES ('writer')"); err != nil {
+		t.Fatalf("contended write failed instead of waiting: %v", err)
+	}
+
+	select {
+	case <-released:
+	default:
+		t.Error("contended write completed before the write lock was released")
+	}
+}
+
+func TestOpenSQLitePoolLimits(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        SQLiteOptions
+		wantMaxOpen int
+	}{
+		{
+			name:        "unset uses defaults",
+			opts:        SQLiteOptions{},
+			wantMaxOpen: DefaultMaxOpenConns,
+		},
+		{
+			name:        "explicit limits are kept",
+			opts:        SQLiteOptions{MaxOpenConns: 5, MaxIdleConns: 2, ConnMaxLifetime: time.Hour},
+			wantMaxOpen: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := tt.opts
+			opts.Path = filepath.Join(t.TempDir(), "test.db")
+
+			db, err := OpenSQLite(opts)
+			if err != nil {
+				t.Fatalf("OpenSQLite() error = %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+
+			if got := db.Stats().MaxOpenConnections; got != tt.wantMaxOpen {
+				t.Errorf("MaxOpenConnections = %d, want %d", got, tt.wantMaxOpen)
+			}
+		})
+	}
+}
+
+func TestOpenSQLiteUnwritableDirectory(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "readonly")
+	if err := os.Mkdir(parent, 0o500); err != nil {
+		t.Fatalf("create read-only directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	if _, err := OpenSQLite(SQLiteOptions{Path: filepath.Join(parent, "sub", "test.db")}); err == nil {
+		t.Fatal("OpenSQLite() error = nil, want an error for an unwritable directory")
+	}
+}

--- a/pkg/database/types.go
+++ b/pkg/database/types.go
@@ -3,7 +3,6 @@ package database
 import (
 	"database/sql"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -55,24 +54,8 @@ func NewDatabase(config Config) (*Database, error) {
 		config.Driver = "sqlite"
 	}
 
-	db, err := sql.Open(config.Driver, config.Path)
+	db, err := openForDriver(config)
 	if err != nil {
-		return nil, err
-	}
-
-	if config.Driver == "sqlite" {
-		if err := configureSQLitePragmas(db); err != nil {
-			closeDBOnError(db)
-			return nil, err
-		}
-	}
-
-	db.SetMaxOpenConns(10)
-	db.SetMaxIdleConns(5)
-	db.SetConnMaxLifetime(time.Hour)
-
-	if err := db.Ping(); err != nil {
-		closeDBOnError(db)
 		return nil, err
 	}
 
@@ -84,38 +67,35 @@ func NewDatabase(config Config) (*Database, error) {
 	return database, nil
 }
 
+// openForDriver opens the connection for the configured driver. SQLite goes
+// through the shared OpenSQLite helper; any other driver gets a plain connection
+// with the same pool limits and health check, because the pragmas are
+// SQLite-specific.
+func openForDriver(config Config) (*sql.DB, error) {
+	opts := SQLiteOptions{Path: config.Path, ConnMaxLifetime: time.Hour}
+	if config.Driver == "sqlite" {
+		return OpenSQLite(opts)
+	}
+
+	db, err := sql.Open(config.Driver, config.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	applyPoolLimits(db, opts)
+
+	if err := db.Ping(); err != nil {
+		closeDBOnError(db)
+		return nil, err
+	}
+
+	return db, nil
+}
+
 func closeDBOnError(db *sql.DB) {
 	if err := db.Close(); err != nil {
 		slog.Error("Failed to close database", "error", err)
 	}
-}
-
-func configureSQLitePragmas(db *sql.DB) error {
-	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
-		return err
-	}
-
-	var journalMode string
-	if err := db.QueryRow("PRAGMA journal_mode;").Scan(&journalMode); err != nil {
-		return err
-	}
-	if !strings.EqualFold(journalMode, "wal") {
-		if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-			return err
-		}
-	}
-
-	pragmas := []string{
-		"PRAGMA synchronous=NORMAL",
-		"PRAGMA temp_store=memory",
-		"PRAGMA mmap_size=268435456",
-	}
-	for _, pragma := range pragmas {
-		if _, err := db.Exec(pragma); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // Close closes the database connection

--- a/pkg/httpcache/cache.go
+++ b/pkg/httpcache/cache.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/lepinkainen/feed-forge/pkg/api"
+	"github.com/lepinkainen/feed-forge/pkg/database"
 	"github.com/lepinkainen/feed-forge/pkg/filesystem"
-	_ "modernc.org/sqlite" // SQLite driver
 )
 
 // ErrNotModified signals that upstream returned HTTP 304 Not Modified.
@@ -124,19 +124,12 @@ func NewStore(dbPath string) (*Store, error) {
 		}
 	}
 
-	if err := filesystem.EnsureDirectoryExists(dbPath); err != nil {
-		return nil, fmt.Errorf("create cache directory: %w", err)
-	}
-
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := database.OpenSQLite(database.SQLiteOptions{
+		Path:         dbPath,
+		MaxOpenConns: 5,
+		MaxIdleConns: 2,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("open http cache: %w", err)
-	}
-
-	if err := configureSQLite(db); err != nil {
-		if closeErr := db.Close(); closeErr != nil {
-			slog.Error("Failed to close HTTP cache database", "error", closeErr)
-		}
 		return nil, err
 	}
 
@@ -149,37 +142,6 @@ func NewStore(dbPath string) (*Store, error) {
 	}
 
 	return store, nil
-}
-
-func configureSQLite(db *sql.DB) error {
-	ctx := context.Background()
-	if _, err := db.ExecContext(ctx, "PRAGMA busy_timeout=5000"); err != nil {
-		return fmt.Errorf("set busy timeout: %w", err)
-	}
-
-	var journalMode string
-	if err := db.QueryRowContext(ctx, "PRAGMA journal_mode;").Scan(&journalMode); err != nil {
-		return fmt.Errorf("read journal mode: %w", err)
-	}
-	if !strings.EqualFold(journalMode, "wal") {
-		if _, err := db.ExecContext(ctx, "PRAGMA journal_mode=WAL"); err != nil {
-			return fmt.Errorf("set journal mode: %w", err)
-		}
-	}
-
-	for _, pragma := range []string{
-		"PRAGMA synchronous=NORMAL",
-		"PRAGMA temp_store=memory",
-		"PRAGMA mmap_size=268435456",
-	} {
-		if _, err := db.ExecContext(ctx, pragma); err != nil {
-			return fmt.Errorf("set pragma %q: %w", pragma, err)
-		}
-	}
-
-	db.SetMaxOpenConns(5)
-	db.SetMaxIdleConns(2)
-	return nil
 }
 
 func (s *Store) createSchema() error {

--- a/pkg/opengraph/database.go
+++ b/pkg/opengraph/database.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/lepinkainen/feed-forge/pkg/database"
 	"github.com/lepinkainen/feed-forge/pkg/dbinterfaces"
-	"github.com/lepinkainen/feed-forge/pkg/filesystem"
-	_ "modernc.org/sqlite" // SQLite driver
 )
 
 // Database wraps database operations with thread safety
@@ -32,26 +31,9 @@ func NewDatabase(dbPath string) (*Database, error) {
 		dbPath = DefaultDBFile
 	}
 
-	if err := filesystem.EnsureDirectoryExists(dbPath); err != nil {
-		return nil, fmt.Errorf("failed to create directory: %w", err)
-	}
-
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := database.OpenSQLite(database.SQLiteOptions{Path: dbPath})
 	if err != nil {
-		return nil, fmt.Errorf("failed to open database: %w", err)
-	}
-
-	if err := configureSQLite(db); err != nil {
-		closeDBOnError(db)
 		return nil, err
-	}
-
-	db.SetMaxOpenConns(10)
-	db.SetMaxIdleConns(5)
-
-	if err := db.Ping(); err != nil {
-		closeDBOnError(db)
-		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
 	ogDB := &Database{
@@ -59,46 +41,14 @@ func NewDatabase(dbPath string) (*Database, error) {
 		dbPath: dbPath,
 	}
 	if err := ogDB.createSchema(); err != nil {
-		closeDBOnError(db)
+		if closeErr := ogDB.Close(); closeErr != nil {
+			slog.Error("Failed to close database", "error", closeErr)
+		}
 		return nil, fmt.Errorf("failed to create schema: %w", err)
 	}
 
 	slog.Info("OpenGraph database initialized", "path", dbPath)
 	return ogDB, nil
-}
-
-func closeDBOnError(db *sql.DB) {
-	if err := db.Close(); err != nil {
-		slog.Error("Failed to close database", "error", err)
-	}
-}
-
-func configureSQLite(db *sql.DB) error {
-	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
-		return fmt.Errorf("failed to set busy timeout: %w", err)
-	}
-
-	var journalMode string
-	if err := db.QueryRow("PRAGMA journal_mode;").Scan(&journalMode); err != nil {
-		return fmt.Errorf("failed to read journal mode: %w", err)
-	}
-	if !strings.EqualFold(journalMode, "wal") {
-		if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-			return fmt.Errorf("failed to set journal mode: %w", err)
-		}
-	}
-
-	pragmas := []string{
-		"PRAGMA synchronous=NORMAL",
-		"PRAGMA temp_store=memory",
-		"PRAGMA mmap_size=268435456",
-	}
-	for _, pragma := range pragmas {
-		if _, err := db.Exec(pragma); err != nil {
-			return fmt.Errorf("failed to set pragma %q: %w", pragma, err)
-		}
-	}
-	return nil
 }
 
 // createSchema creates the necessary tables

--- a/pkg/opengraph/database_test.go
+++ b/pkg/opengraph/database_test.go
@@ -1,6 +1,7 @@
 package opengraph
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -145,6 +146,73 @@ func TestDatabaseCleanupExpiredAndStats(t *testing.T) {
 	}
 	if stats["expired_entries"] != 0 {
 		t.Fatalf("expired_entries after cleanup = %v, want 0", stats["expired_entries"])
+	}
+}
+
+// TestSaveCachedDataUnderWriteContention covers the failure seen in production:
+// the generate command runs its providers concurrently and every provider opens
+// its own handle on one shared opengraph.db, so a save can land while another
+// handle holds the write lock. The per-connection busy_timeout must make the save
+// wait instead of returning "database is locked (5) (SQLITE_BUSY)".
+func TestSaveCachedDataUnderWriteContention(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "opengraph.db")
+
+	writer, err := NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("NewDatabase(writer) error = %v", err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+
+	blocker, err := NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("NewDatabase(blocker) error = %v", err)
+	}
+	t.Cleanup(func() { _ = blocker.Close() })
+
+	// Pin the writer's first connection so the save below runs on a connection the
+	// pool creates afterwards. Only that first connection would be configured if
+	// the pragmas were applied as statements instead of through the DSN.
+	pinned, err := writer.db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Conn() error = %v", err)
+	}
+	t.Cleanup(func() { _ = pinned.Close() })
+
+	tx, err := blocker.db.Begin()
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	if _, err := tx.Exec(
+		"INSERT OR REPLACE INTO opengraph_cache (url, expires_at) VALUES (?, CURRENT_TIMESTAMP)",
+		"https://example.com/blocker",
+	); err != nil {
+		t.Fatalf("blocker insert: %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		close(released)
+		if err := tx.Commit(); err != nil {
+			t.Errorf("blocker commit: %v", err)
+		}
+	}()
+
+	now := time.Now().UTC()
+	data := &Data{
+		URL:       "https://example.com/contended",
+		Title:     "Contended",
+		FetchedAt: now,
+		ExpiresAt: now.Add(24 * time.Hour),
+	}
+	if err := writer.SaveCachedData(data, true); err != nil {
+		t.Fatalf("SaveCachedData() failed instead of waiting for the write lock: %v", err)
+	}
+
+	select {
+	case <-released:
+	default:
+		t.Error("SaveCachedData() returned before the write lock was released")
 	}
 }
 


### PR DESCRIPTION
Closes #40.

## What this does

Two things, in this order: it deduplicates the SQLite connection setup that four packages had each grown their own copy of, and then it fixes the `SQLITE_BUSY` failures that the duplication had been hiding.

## Part 1: one shared helper

New `pkg/database.OpenSQLite(SQLiteOptions)` creates the parent directory, applies the pragmas, sets the pool limits and pings. Four packages call it and keep their own struct, locking, schema and queries:

| File | Before | After |
|---|---|---|
| `pkg/database/types.go` | inline setup, 10/5 conns, 1h lifetime | `openForDriver` sends sqlite through the helper, other drivers keep a plain open plus the same limits and ping |
| `pkg/opengraph/database.go` | own copy, 10/5, no lifetime | helper, defaults |
| `pkg/httpcache/cache.go` | own copy, 5/2, no ping | helper, 5/2 |
| `internal/bulletin/store.go` | partial copy, no pool limits, no ping, unconditional WAL | helper, defaults |

The copies had drifted: bulletin was missing `temp_store`, `mmap_size` and pool limits, and two of the four never pinged. `pkg/database` also becomes the single place that registers the driver.

## Part 2: the actual bug

The pragmas now ride in the DSN as `_pragma` query parameters instead of running as statements after `sql.Open`:

```
/path/opengraph.db?_pragma=busy_timeout%3D5000&_pragma=synchronous%3DNORMAL&...
```

`busy_timeout`, `synchronous`, `temp_store` and `mmap_size` are per-connection settings. Running them as statements configured whichever single pooled connection happened to serve them and left every connection `database/sql` added afterwards at the SQLite defaults, `busy_timeout=0` among them. Measured on the old code:

```
conn1 busy_timeout=5000   conn2 busy_timeout=0   conn3 busy_timeout=0
```

So a contended write failed instantly instead of waiting, which is the cron failure that prompted this:

```
WARN Failed to cache OpenGraph data url=https://aeon.co/essays/...
  error="failed to save cached data: database is locked (5) (SQLITE_BUSY)"
```

`opengraph.db` saw it worst because `generate` runs its providers concurrently and each one opens its own pool of up to 10 connections on that one shared file. The driver applies DSN pragmas in `newConn`, so every connection now gets them.

`journal_mode` stays a one-time conditional statement in `ensureWAL`: it lives in the database file rather than on the connection, and converting a database needs an exclusive lock, so a redundant conversion attempt can fail against a busy file. The path is deliberately not prefixed with `file:`, so the driver treats everything before the `?` as a literal path, which keeps `:memory:` and unescaped paths working.

## Tests

Three new tests, each verified to fail against the previous behaviour rather than merely assumed to cover it. The trick that makes them deterministic is pinning the pool's first connection, since that is the only one the old code configured.

- `TestOpenSQLitePragmasApplyToEveryPooledConnection` — old code: `connection #2: busy_timeout = 0, want 5000`, plus `synchronous` and `temp_store`.
- `TestOpenSQLiteContendedWriteWaits` — two handles on one file, one holds a write transaction for 250ms. Old code: `contended write failed instead of waiting: database is locked (5) (SQLITE_BUSY)`.
- `TestSaveCachedDataUnderWriteContention` — the same scenario through `opengraph.SaveCachedData`, mirroring the production failure.

Plus directory creation, pragma assertions, table-driven pool-limit defaults, and an unwritable-directory error case.

## Verification

- `task build` (runs test and lint) green; `task lint` reports 0 issues.
- `go test -race -count=2` green on all four touched packages.
- `task deadcode` reports only 4 pre-existing test-stub hits, and one `configureSQLitePragmas` is left repo-wide.
- Deleted `~/.cache/feed-forge/opengraph.db` and ran `feed-forge hackernews`: recreated with `journal_mode=wal` and 8 rows. `bulletin-fetch` against a temp config created `bulletin.db` in `wal` with 25 items.

## Follow-up

#70 covers cutting the connection count itself, which this PR does not address. Writes now wait rather than fail, but each provider still opens its own pool on the shared files.
