### PR TITLE
feat(version): inject build version and verify remote publish

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,12 +1,16 @@
 version: "3"
 
+vars:
+  VERSION:
+    sh: git describe --tags --always --dirty 2>/dev/null || echo dev
+
 tasks:
   build:
     desc: "Build the feed-forge binary"
     deps: [test, lint]
     cmds:
       - mkdir -p build
-      - go build -o build/feed-forge cmd/feed-forge/main.go
+      - go build -ldflags "-X github.com/lepinkainen/feed-forge/pkg/version.Version={{.VERSION}}" -o build/feed-forge cmd/feed-forge/main.go
 
   test:
     desc: "Run tests"
@@ -54,13 +58,13 @@ tasks:
     deps: [test, lint]
     cmds:
       - mkdir -p build
-      - GOOS=linux GOARCH=amd64 go build -o build/feed-forge-linux cmd/feed-forge/main.go
+      - GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/lepinkainen/feed-forge/pkg/version.Version={{.VERSION}}" -o build/feed-forge-linux cmd/feed-forge/main.go
 
   build-ci:
     desc: "Build for CI environment"
     cmds:
       - mkdir -p build
-      - go build -o build/feed-forge cmd/feed-forge/main.go
+      - go build -ldflags "-X github.com/lepinkainen/feed-forge/pkg/version.Version={{.VERSION}}" -o build/feed-forge cmd/feed-forge/main.go
 
   test-ci:
     desc: "Run tests with CI tags and coverage"
@@ -160,6 +164,12 @@ tasks:
     deps: [build-linux]
     cmds:
       - scp build/feed-forge-linux ${PUBLISH_DESTINATION}
+      - |
+        host="${PUBLISH_DESTINATION%%:*}"
+        dest="${PUBLISH_DESTINATION#*:}"
+        bin=$(ssh "$host" "test -d '$dest' && echo '$dest/feed-forge-linux' || echo '$dest'")
+        echo "Remote version:"
+        ssh "$host" "'$bin' --version"
 
   help:
     desc: "Show available tasks"

--- a/cmd/feed-forge/main.go
+++ b/cmd/feed-forge/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lepinkainen/feed-forge/pkg/notifications"
 	"github.com/lepinkainen/feed-forge/pkg/preview"
 	"github.com/lepinkainen/feed-forge/pkg/providers"
+	"github.com/lepinkainen/feed-forge/pkg/version"
 
 	"github.com/lepinkainen/feed-forge/internal/bulletin"
 
@@ -42,12 +43,13 @@ import (
 
 // CLI structure
 var CLI struct {
-	Config            string `help:"Configuration file path" default:"config.yaml"`
-	Debug             bool   `help:"Enable debug logging" default:"false"`
-	OutputDir         string `help:"Base output directory for all generated feeds" default:"" yaml:"output-dir"`
-	FeedBaseURL       string `help:"Public base URL for generated feeds and OPML" default:"https://endymion.xyz/rss/" yaml:"feed-base-url"`
-	CacheDir          string `help:"Directory for cache databases" default:"" yaml:"cache-dir"`
-	DiscordWebhookURL string `help:"Discord webhook URL for failure notifications" default:"" yaml:"discord-webhook-url"`
+	Version           kong.VersionFlag `help:"Print version and exit"`
+	Config            string           `help:"Configuration file path" default:"config.yaml"`
+	Debug             bool             `help:"Enable debug logging" default:"false"`
+	OutputDir         string           `help:"Base output directory for all generated feeds" default:"" yaml:"output-dir"`
+	FeedBaseURL       string           `help:"Public base URL for generated feeds and OPML" default:"https://endymion.xyz/rss/" yaml:"feed-base-url"`
+	CacheDir          string           `help:"Directory for cache databases" default:"" yaml:"cache-dir"`
+	DiscordWebhookURL string           `help:"Discord webhook URL for failure notifications" default:"" yaml:"discord-webhook-url"`
 
 	Reddit struct {
 		Outfile     string `help:"Output file path" short:"o" default:"reddit.xml"`
@@ -744,6 +746,7 @@ func main() {
 		kong.Description("A unified RSS feed generator with multiple provider support."),
 		kong.UsageOnError(),
 		kong.Configuration(kongyaml.Loader, configPath),
+		kong.Vars{"version": version.Version},
 	)
 
 	// Configure logging level based on debug flag

--- a/pkg/api/enhanced_client.go
+++ b/pkg/api/enhanced_client.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/lepinkainen/feed-forge/pkg/version"
 )
 
 // EnhancedClientConfig configures the enhanced HTTP client
@@ -56,7 +58,7 @@ func NewEnhancedClient(config *EnhancedClientConfig) *EnhancedClient {
 		config.RetryPolicy = DefaultRetryPolicy()
 	}
 	if config.UserAgent == "" {
-		config.UserAgent = "FeedForge/1.0"
+		config.UserAgent = "FeedForge/" + version.Version
 	}
 	if config.DefaultHeaders == nil {
 		config.DefaultHeaders = make(map[string]string)
@@ -344,7 +346,7 @@ func NewRedditClient(baseClient *http.Client) *EnhancedClient {
 		BaseClient:  baseClient,
 		RateLimiter: NewSimpleRateLimiter(2 * time.Second), // Reddit rate limit - generous to avoid 429s
 		RetryPolicy: DefaultRetryPolicy(),
-		UserAgent:   "FeedForge/1.0 by theshrike79",
+		UserAgent:   "FeedForge/" + version.Version + " by theshrike79",
 		DefaultHeaders: map[string]string{
 			"Accept": "application/json",
 		},
@@ -357,7 +359,7 @@ func NewHackerNewsClient() *EnhancedClient {
 		BaseClient:  &http.Client{Timeout: 30 * time.Second},
 		RateLimiter: NewSimpleRateLimiter(500 * time.Millisecond), // Conservative rate limit
 		RetryPolicy: ConservativeRetryPolicy(),
-		UserAgent:   "FeedForge/1.0",
+		UserAgent:   "FeedForge/" + version.Version,
 		DefaultHeaders: map[string]string{
 			"Accept": "application/json",
 		},
@@ -370,6 +372,6 @@ func NewGenericClient() *EnhancedClient {
 		BaseClient:  &http.Client{Timeout: 30 * time.Second},
 		RateLimiter: NewNoOpRateLimiter(), // No rate limiting by default
 		RetryPolicy: ConservativeRetryPolicy(),
-		UserAgent:   "FeedForge/1.0",
+		UserAgent:   "FeedForge/" + version.Version,
 	})
 }

--- a/pkg/api/enhanced_client_test.go
+++ b/pkg/api/enhanced_client_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/lepinkainen/feed-forge/pkg/version"
 )
 
 func TestNewEnhancedClient(t *testing.T) {
@@ -21,7 +23,7 @@ func TestNewEnhancedClient(t *testing.T) {
 			config: &EnhancedClientConfig{},
 			want: func(ec *EnhancedClient) bool {
 				return ec.client.Timeout == 30*time.Second &&
-					ec.userAgent == "FeedForge/1.0" &&
+					ec.userAgent == "FeedForge/"+version.Version &&
 					ec.rateLimiter != nil &&
 					ec.retryPolicy != nil &&
 					ec.defaultHeaders != nil
@@ -276,7 +278,7 @@ func TestNewHackerNewsClient(t *testing.T) {
 		t.Errorf("NewHackerNewsClient() timeout incorrect")
 	}
 
-	if client.userAgent != "FeedForge/1.0" {
+	if client.userAgent != "FeedForge/"+version.Version {
 		t.Errorf("NewHackerNewsClient() user agent incorrect: %s", client.userAgent)
 	}
 
@@ -292,7 +294,7 @@ func TestNewGenericClient(t *testing.T) {
 		t.Errorf("NewGenericClient() timeout incorrect")
 	}
 
-	if client.userAgent != "FeedForge/1.0" {
+	if client.userAgent != "FeedForge/"+version.Version {
 		t.Errorf("NewGenericClient() user agent incorrect: %s", client.userAgent)
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,6 @@
+// Package version holds the build version of feed-forge.
+package version
+
+// Version is the build version. It is overridden at build time with
+// -ldflags "-X github.com/lepinkainen/feed-forge/pkg/version.Version=...".
+var Version = "dev"


### PR DESCRIPTION
## What

Add build-time version plumbing (llm-shared convention) and a read-only remote publish check.

- New `pkg/version` package: `Version` var overridden at build time via `-ldflags -X ...version.Version=<git describe>`.
- Kong `--version` flag on the CLI.
- `pkg/api` user agent now `FeedForge/<version>` instead of the hardcoded `FeedForge/1.0`.
- `Taskfile` `build`, `build-linux`, `build-ci` inject `git describe --tags --always --dirty` (falls back to `dev`).
- `task publish` gains a post-`scp` step that runs the deployed binary with `--version` over ssh — a read-only check that the transfer is intact, executable, and the right architecture.

## Verification

- `task build` green (test + lint + vet + mod tidy + build).
- Built binary: `feed-forge --version` prints the injected version.
- `task --dry publish` shows the resolved ldflags and the ssh probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)