### PR TITLE
perf(opengraph): skip fetches for URLs that cannot carry OG tags

### DIFF
--- a/pkg/opengraph/fetcher.go
+++ b/pkg/opengraph/fetcher.go
@@ -66,13 +66,35 @@ func (f *Fetcher) FetchData(targetURL string) (*Data, error) {
 	return f.FetchDataWithContext(context.Background(), targetURL)
 }
 
-// FetchDataWithContext fetches OpenGraph data from a URL with caching.
-func (f *Fetcher) FetchDataWithContext(ctx context.Context, targetURL string) (*Data, error) {
+// precheckURL decides whether targetURL is worth fetching at all. It returns
+// skip for a URL that has no OpenGraph data to offer, which callers report as
+// "no data" rather than as an error, and an error for a URL that must not be
+// fetched.
+func (f *Fetcher) precheckURL(ctx context.Context, targetURL string) (skip bool, err error) {
+	// Checked before the fetchability test, which resolves the hostname: for a
+	// feed full of image links this skips the DNS lookups too, not just the
+	// HTTP requests.
+	if isNonPageURL(targetURL) {
+		slog.Debug("Skipping URL that cannot carry OpenGraph tags", "url", targetURL)
+		return true, nil
+	}
 	if !urlutils.IsFetchableURLWithContext(ctx, f.resolver, targetURL) {
-		return nil, fmt.Errorf("invalid or disallowed fetch URL: %s", targetURL)
+		return false, fmt.Errorf("invalid or disallowed fetch URL: %s", targetURL)
 	}
 	if f.isBlockedURL(targetURL) {
 		slog.Debug("Skipping blocked URL", "url", targetURL)
+		return true, nil
+	}
+	return false, nil
+}
+
+// FetchDataWithContext fetches OpenGraph data from a URL with caching.
+func (f *Fetcher) FetchDataWithContext(ctx context.Context, targetURL string) (*Data, error) {
+	skipFetch, err := f.precheckURL(ctx, targetURL)
+	if err != nil {
+		return nil, err
+	}
+	if skipFetch {
 		return nil, nil
 	}
 

--- a/pkg/opengraph/fetcher.go
+++ b/pkg/opengraph/fetcher.go
@@ -71,9 +71,15 @@ func (f *Fetcher) FetchData(targetURL string) (*Data, error) {
 // "no data" rather than as an error, and an error for a URL that must not be
 // fetched.
 func (f *Fetcher) precheckURL(ctx context.Context, targetURL string) (skip bool, err error) {
-	// Checked before the fetchability test, which resolves the hostname: for a
-	// feed full of image links this skips the DNS lookups too, not just the
-	// HTTP requests.
+	// Rejected first, and without resolving anything: a relative URL, a
+	// non-HTTP scheme, localhost, or a literal IP is an error whether or not it
+	// looks like a media file, so an unsafe URL cannot hide behind a .jpg.
+	if !urlutils.IsFetchableURLSyntax(targetURL) {
+		return false, fmt.Errorf("invalid or disallowed fetch URL: %s", targetURL)
+	}
+	// Then the extension check, still ahead of the resolving fetchability test:
+	// for a feed full of image links this skips the DNS lookups too, not just
+	// the HTTP requests.
 	if isNonPageURL(targetURL) {
 		slog.Debug("Skipping URL that cannot carry OpenGraph tags", "url", targetURL)
 		return true, nil

--- a/pkg/opengraph/fetcher_test.go
+++ b/pkg/opengraph/fetcher_test.go
@@ -62,6 +62,10 @@ func TestFetchData_InvalidAndBlockedURLs(t *testing.T) {
 		t.Fatalf("FetchData(blocked) = (%#v, %v), want (nil, nil)", data, err)
 	}
 
+	if data, err := fetcher.FetchData("https://lemmy.world/pictrs/image/x.jpeg"); err != nil || data != nil {
+		t.Fatalf("FetchData(image) = (%#v, %v), want (nil, nil)", data, err)
+	}
+
 	if fetcher.isBlockedURL("https://evil.example/?next=twitter.com") {
 		t.Fatal("isBlockedURL(query containing blocked hostname) = true, want false")
 	}
@@ -107,6 +111,76 @@ func TestFetchData_UsesCacheAndRecentFailure(t *testing.T) {
 	data, err := fetcher.FetchData(failedURL)
 	if err != nil || data != nil {
 		t.Fatalf("FetchData(recent failure) = (%#v, %v), want (nil, nil)", data, err)
+	}
+}
+
+func TestIsNonPageURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "jpeg image", url: "https://lemmy.world/pictrs/image/08675766.jpeg", want: true},
+		{name: "jpg image", url: "https://media.piefed.world/posts/vW/3u/vW3u8B3uA5VbHFh.jpg", want: true},
+		{name: "png image", url: "https://i.redd.it/abc123.png", want: true},
+		{name: "webp image", url: "https://lemmy.blahaj.zone/pictrs/image/d95ad6ca.webp", want: true},
+		{name: "video", url: "https://example.com/clip.mp4", want: true},
+		{name: "audio", url: "https://example.com/episode.mp3", want: true},
+		{name: "pdf document", url: "https://example.com/paper.pdf", want: true},
+		{name: "archive", url: "https://example.com/release.tar.gz", want: true},
+		{name: "upper-case extension", url: "https://example.com/PHOTO.JPG", want: true},
+		{name: "query string after the extension", url: "https://example.com/image.jpeg?format=webp&w=800", want: true},
+
+		{name: "article", url: "https://futurism.com/artificial-intelligence/boomers-facebook", want: false},
+		{name: "html page", url: "https://example.com/index.html", want: false},
+		// Older pictrs URLs carry no extension, so the content-type check in
+		// fetchFreshData still has to catch those.
+		{name: "extensionless media", url: "https://lemmy.world/pictrs/image/08675766", want: false},
+		{name: "fragment containing a dot", url: "https://example.com/page#section.png", want: false},
+		{name: "dot in a path segment, no extension", url: "https://example.com/v1.2/release-notes", want: false},
+		// Must stay false so FetchDataWithContext still reports it as invalid
+		// rather than silently skipping it.
+		{name: "unparseable url", url: "://bad.jpg", want: false},
+		{name: "empty string", url: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNonPageURL(tt.url); got != tt.want {
+				t.Errorf("isNonPageURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFetchData_NonPageURLMakesNoRequest proves the extension check happens
+// before any network work: the handler must never run.
+func TestFetchData_NonPageURLMakesNoRequest(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("not html"))
+	}))
+	defer server.Close()
+
+	var lookups atomic.Int32
+	fetcher := NewFetcher(newTestOGDB(t))
+	fetcher.resolver = testutil.StubResolver{Lookup: func(context.Context, string) ([]net.IPAddr, error) {
+		lookups.Add(1)
+		return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}}, nil
+	}}
+	fetcher.client.Transport = rewriteHostTransport(server)
+
+	data, err := fetcher.FetchData("http://example.invalid/pictrs/image/abc.jpeg")
+	if err != nil || data != nil {
+		t.Fatalf("FetchData(image) = (%#v, %v), want (nil, nil)", data, err)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Errorf("server was hit %d times, want 0", got)
+	}
+	if got := lookups.Load(); got != 0 {
+		t.Errorf("hostname was resolved %d times, want 0", got)
 	}
 }
 

--- a/pkg/opengraph/fetcher_test.go
+++ b/pkg/opengraph/fetcher_test.go
@@ -66,6 +66,20 @@ func TestFetchData_InvalidAndBlockedURLs(t *testing.T) {
 		t.Fatalf("FetchData(image) = (%#v, %v), want (nil, nil)", data, err)
 	}
 
+	// A media extension must not let an unsafe URL through as "no data": these
+	// stay errors, exactly as they were before the extension check existed.
+	for _, unsafe := range []string{
+		"http://127.0.0.1/x.jpg",
+		"http://localhost/x.jpg",
+		"file:///tmp/x.jpg",
+		"/x.jpg",
+		"://bad.jpg",
+	} {
+		if data, err := fetcher.FetchData(unsafe); err == nil || data != nil {
+			t.Errorf("FetchData(%q) = (%#v, %v), want error", unsafe, data, err)
+		}
+	}
+
 	if fetcher.isBlockedURL("https://evil.example/?next=twitter.com") {
 		t.Fatal("isBlockedURL(query containing blocked hostname) = true, want false")
 	}

--- a/pkg/opengraph/url_policy.go
+++ b/pkg/opengraph/url_policy.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -53,6 +54,41 @@ func (f *Fetcher) isBlockedURL(targetURL string) bool {
 	}
 
 	return false
+}
+
+// nonPageExtensions are path extensions whose content can never carry OpenGraph
+// tags. A feed item linking to one of these is usually pointing at its own
+// media — a Lemmy pictrs image, an i.redd.it upload — so a request would spend a
+// DNS lookup, a connect and a header read only to learn what the extension
+// already said.
+var nonPageExtensions = map[string]struct{}{
+	// Images
+	".jpg": {}, ".jpeg": {}, ".png": {}, ".gif": {}, ".webp": {},
+	".avif": {}, ".bmp": {}, ".svg": {}, ".ico": {}, ".tif": {}, ".tiff": {},
+	// Video
+	".mp4": {}, ".webm": {}, ".mkv": {}, ".mov": {}, ".avi": {}, ".m4v": {},
+	// Audio
+	".mp3": {}, ".ogg": {}, ".oga": {}, ".opus": {}, ".flac": {}, ".wav": {}, ".m4a": {},
+	// Documents and archives
+	".pdf": {}, ".zip": {}, ".gz": {}, ".tgz": {}, ".tar": {}, ".7z": {}, ".rar": {},
+}
+
+// isNonPageURL reports whether targetURL points at a file that cannot carry
+// OpenGraph tags, judged from its path extension.
+//
+// A URL that does not parse returns false, so FetchDataWithContext keeps
+// reporting it as an invalid fetch URL instead of silently skipping it.
+func isNonPageURL(targetURL string) bool {
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		return false
+	}
+
+	// Take the extension from the parsed path so a query string or a fragment
+	// cannot be mistaken for one, as in "/image.jpeg?format=webp".
+	ext := strings.ToLower(path.Ext(parsedURL.Path))
+	_, nonPage := nonPageExtensions[ext]
+	return nonPage
 }
 
 func hostnameFromURL(targetURL string) (string, error) {

--- a/pkg/urlutils/url.go
+++ b/pkg/urlutils/url.go
@@ -20,8 +20,16 @@ type LookupIPAddrsResolver interface {
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
 }
 
-// IsFetchableURLWithContext checks whether a URL is safe for outbound HTTP fetching.
-func IsFetchableURLWithContext(ctx context.Context, resolver LookupIPAddrsResolver, urlStr string) bool {
+// IsFetchableURLSyntax reports whether a URL is safe for outbound HTTP fetching
+// as far as inspection alone can tell, without resolving the hostname. It
+// rejects a relative URL, a non-HTTP scheme, localhost, and a literal IP
+// address.
+//
+// Callers that will not fetch the URL after all can use this to reject the
+// clearly-unsafe cases without paying for a DNS lookup. A true result does not
+// mean the URL is fetchable — only IsFetchableURLWithContext can say that,
+// because the hostname may still resolve to a blocked address.
+func IsFetchableURLSyntax(urlStr string) bool {
 	u, err := url.Parse(urlStr)
 	if err != nil || u.Host == "" {
 		return false
@@ -31,16 +39,38 @@ func IsFetchableURLWithContext(ctx context.Context, resolver LookupIPAddrsResolv
 		return false
 	}
 
+	return isFetchableHostnameSyntax(u.Hostname())
+}
+
+// isFetchableHostnameSyntax holds the checks that need no name resolution.
+func isFetchableHostnameSyntax(hostname string) bool {
+	if hostname == "" || strings.EqualFold(hostname, "localhost") {
+		return false
+	}
+
+	// A literal IP bypasses the resolve-then-check path below, so it is never
+	// accepted here.
+	_, err := netip.ParseAddr(hostname)
+	return err != nil
+}
+
+// IsFetchableURLWithContext checks whether a URL is safe for outbound HTTP fetching.
+func IsFetchableURLWithContext(ctx context.Context, resolver LookupIPAddrsResolver, urlStr string) bool {
+	if !IsFetchableURLSyntax(urlStr) {
+		return false
+	}
+
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+
 	return IsFetchableHostname(ctx, resolver, u.Hostname())
 }
 
 // IsFetchableHostname checks whether a hostname is safe for outbound HTTP fetching.
 func IsFetchableHostname(ctx context.Context, resolver LookupIPAddrsResolver, hostname string) bool {
-	if hostname == "" || strings.EqualFold(hostname, "localhost") {
-		return false
-	}
-
-	if _, err := netip.ParseAddr(hostname); err == nil {
+	if !isFetchableHostnameSyntax(hostname) {
 		return false
 	}
 

--- a/pkg/urlutils/url_test.go
+++ b/pkg/urlutils/url_test.go
@@ -34,6 +34,54 @@ func TestIsValidURL(t *testing.T) {
 	}
 }
 
+func TestIsFetchableURLSyntax(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{name: "https host", url: "https://example.com/page", expected: true},
+		{name: "http host", url: "http://example.com/image.jpg", expected: true},
+		{name: "host with port", url: "https://example.com:8443/page", expected: true},
+
+		{name: "relative path", url: "/x.jpg", expected: false},
+		{name: "bare domain, no scheme", url: "example.com/x.jpg", expected: false},
+		{name: "file scheme", url: "file:///tmp/x.jpg", expected: false},
+		{name: "ftp scheme", url: "ftp://files.example.com/x.jpg", expected: false},
+		{name: "localhost", url: "http://localhost/x.jpg", expected: false},
+		{name: "localhost, mixed case", url: "http://LocalHost/x.jpg", expected: false},
+		{name: "loopback literal", url: "http://127.0.0.1/x.jpg", expected: false},
+		{name: "private literal", url: "http://10.0.0.1/x.jpg", expected: false},
+		{name: "public literal IP is still rejected", url: "http://93.184.216.34/x.jpg", expected: false},
+		{name: "ipv6 literal", url: "http://[::1]/x.jpg", expected: false},
+		{name: "malformed", url: "://bad.jpg", expected: false},
+		{name: "empty", url: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := IsFetchableURLSyntax(tt.url); result != tt.expected {
+				t.Errorf("IsFetchableURLSyntax(%q) = %v, expected %v", tt.url, result, tt.expected)
+			}
+		})
+	}
+
+	t.Run("says nothing about resolution", func(t *testing.T) {
+		// A hostname that resolves to a blocked address passes the syntax check
+		// and is rejected only by IsFetchableURLWithContext.
+		const internal = "http://internal.example/page"
+		if !IsFetchableURLSyntax(internal) {
+			t.Fatalf("IsFetchableURLSyntax(%q) = false, want true", internal)
+		}
+		privateResolver := testutil.StubResolver{Lookup: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("10.1.2.3")}}, nil
+		}}
+		if IsFetchableURLWithContext(context.Background(), privateResolver, internal) {
+			t.Errorf("IsFetchableURLWithContext(%q) = true, want false", internal)
+		}
+	})
+}
+
 func TestIsFetchableURLWithContext(t *testing.T) {
 	publicResolver := testutil.StubResolver{Lookup: func(context.Context, string) ([]net.IPAddr, error) {
 		return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}}, nil


### PR DESCRIPTION
Follow-up to the note at the end of #78. Independent of it — branched from `main`, touches only `pkg/opengraph`.

## Problem

`externalItemURLs` (`pkg/feed/generator.go:81`) hands the OpenGraph fetcher every item link whose target differs from the item's comments link. For an image post that link **is** the image, so the request can only ever end in `not an HTML page: image/jpeg` — after a DNS lookup, a TCP connect, a TLS handshake, and a response header read.

Measured on a real `feed-forge lemmy` run against lemmy.world: 19 URLs fetched, 15 of them `pictrs` images that all failed this way, and two `slrpnk.net` image URLs that hit the 10-second client timeout. Those wasted fetches were roughly 13 of the run's 15 seconds.

The negative cache does not rescue this. `FetchDataWithContext` writes a failure placeholder and `HasRecentFailure` skips a repeat within the hour, but Lemmy mints a fresh `pictrs` URL per post, so nearly every run sees a new set and pays again.

The Reddit provider has the same shape with `i.redd.it` links — which is exactly why `isBlockedURL` already special-cases that one host.

## Change

`isNonPageURL` in `pkg/opengraph/url_policy.go` recognises image, video, audio, document, and archive extensions and the pre-fetch gate skips those URLs entirely.

This extends the policy that already lives in that file rather than filtering in `pkg/feed`, which is how the #78 note originally framed it. Keeping it in `pkg/opengraph` means one policy in one place, and every `FetchData` caller benefits rather than just the feed generator path.

Two details worth reviewing:

- **The check runs before `IsFetchableURLWithContext`**, which resolves the hostname. So the DNS lookups go away too, not just the HTTP requests.
- **An unparseable URL returns `false`, not `true`.** Failing closed would be wrong here: `FetchData("://bad.jpg")` must keep returning its "invalid or disallowed fetch URL" error rather than silently becoming a no-op.

Extensionless media URLs (older `pictrs` paths, CDN links) still fall through to the existing content-type check, so the two layers compose.

`precheckURL` is extracted to hold the three pre-fetch guards. That is not cosmetic — a fourth branch inline put `FetchDataWithContext` at cyclomatic complexity 16 and `golangci-lint` failed the build.

## Why not a HEAD request first

Checking `Content-Type` is more accurate than reading an extension, but that check already exists and already runs on headers alone: `pkg/opengraph/request.go:84-87` aborts before `readAndDecodeBody` at line 89, so no body is transferred. The `not an HTML page` lines in the log *are* that check working.

A HEAD would add a round trip and save nothing, and it cannot help with the expensive case at all — the two `slrpnk.net` images that burned 10 seconds each timed out *awaiting headers*, which a HEAD would do too. Only skipping the request avoids that.

Accepted trade: HTML served at a `.mp4` or `.pdf` URL gets skipped. Judged irrelevant.

## Tests

- `TestFetchData_NonPageURLMakesNoRequest` — asserts zero server hits **and** zero resolver calls for an image URL. Stronger than counting log lines, and it pins the ordering against `IsFetchableURLWithContext`.
- `TestIsNonPageURL` — 18 cases: each extension family, upper-case extensions, a query string after the extension, `.tar.gz`, a fragment containing a dot, a dotted path segment with no extension, an extensionless `pictrs` URL (must stay `false`), and an unparseable URL (must stay `false`).
- `TestFetchData_InvalidAndBlockedURLs` extended with the image case.

## Verification

`task build` passes, `golangci-lint` reports 0 issues.

No regression for a provider whose links are all articles:

```
./build/feed-forge --debug lobsters -o /tmp/lob.xml
  DEBUG Fetching OpenGraph data url_count=24
  DEBUG Completed concurrent OpenGraph fetch successful_fetches=24
```

24 of 24 resolved, 24 link previews rendered, zero skips triggered.

**Not yet measured end to end:** the Lemmy improvement itself, since that provider lives on #78's branch and the feed needs an account token. Once #78 merges:

```fish
rm ~/.cache/feed-forge/opengraph.db   # otherwise this times cache hits
time ./build/feed-forge --debug lemmy -o /tmp/lemmy.xml 2>&1 | rg -c 'not an HTML page'
```

Expect `0`, with `successful_fetches=4` unchanged — the same articles resolved, without the image round trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
